### PR TITLE
Update Contraction process

### DIFF
--- a/fuzzy.py
+++ b/fuzzy.py
@@ -179,6 +179,10 @@ class FuzzyMMC:
 
 				elif vk[i] < vj[i] < wj[i] < wk[i]:
 					delta_new = min(delta_old, min(wj[i] - vk[i], wk[i] - vj[i]))
+				
+				else:  #There is no overlaps between two boxes
+                    			min_overlap_index = -1
+                    			break
 
 				if delta_old - delta_new > 0:
 					min_overlap_index = i


### PR DESCRIPTION
When hyperboxes conflict in all dimensions, they overlap and they should be contracted. However, this algorithm, contracted hyperboxes even if they only conflicted in one dimension.